### PR TITLE
Resolve memory leak

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -28,7 +28,7 @@ var mapIsolationLevel = function(isolationLevelString) {
       ret = 2;
       break;
   }
-  
+
   return ret;
 };
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -6,49 +6,55 @@
 'use strict';
 
 var g = require('./globalize');
-var debug = require('debug')('loopback:connector:db2:transaction');
+var debug = require('debug')('loopback:connector:dashdb:transaction');
 var Transaction = require('loopback-connector').Transaction;
 
 module.exports = mixinTransaction;
 
+var mapIsolationLevel = function(isolationLevelString) {
+  var ret = 2;
+  switch (isolationLevelString) {
+    case Transaction.READ_UNCOMMITTED:
+      ret = 1;
+      break;
+    case Transaction.SERIALIZABLE:
+      ret = 4;
+      break;
+    case Transaction.REPEATABLE_READ:
+      ret = 8;
+      break;
+    case Transaction.READ_COMMITTED:
+    default:
+      ret = 2;
+      break;
+  }
+  
+  return ret;
+};
+
 /*!
- * @param {DB2} DB2 connector class
+ * @param {DASHDB} DASHDB connector class
  */
-function mixinTransaction(DB2, db2) {
+function mixinTransaction(DASHDB, dashdb) {
   /**
    * Begin a new transaction
 
    * @param {Integer} isolationLevel
    * @param {Function} cb
    */
-  DB2.prototype.beginTransaction = function(isolationLevel, cb) {
+  DASHDB.prototype.beginTransaction = function(isolationLevel, cb) {
     debug('Begin a transaction with isolation level: %s', isolationLevel);
 
     var self = this;
-
-    if (isolationLevel !== Transaction.READ_COMMITTED &&
-      isolationLevel !== Transaction.SERIALIZABLE) {
-      var err = new Error(g.f('Invalid isolationLevel: %s', isolationLevel));
-      err.statusCode = 400;
-      return process.nextTick(function() {
-        cb(err);
-      });
-    }
-
-    self.connStr += ';IsolationLevel=ReadCommitted';
 
     self.client.open(self.connStr, function(err, connection) {
       if (err) return cb(err);
       connection.beginTransaction(function(err) {
         if (isolationLevel) {
-          var sql = 'SET CURRENT ISOLATION TO ' + isolationLevel;
-
-          connection.query(sql, function(err) {
-            cb(err, connection);
-          });
-        } else {
-          cb(err, connection);
+          connection.setIsolationLevel(mapIsolationLevel(isolationLevel));
         }
+
+        cb(err, connection);
       });
     });
   };
@@ -59,7 +65,7 @@ function mixinTransaction(DB2, db2) {
    * @param {Object} connection
    * @param {Function} cb
    */
-  DB2.prototype.commit = function(connection, cb) {
+  DASHDB.prototype.commit = function(connection, cb) {
     debug('Commit a transaction');
     connection.commitTransaction(function(err) {
       if (err) return cb(err);
@@ -73,7 +79,7 @@ function mixinTransaction(DB2, db2) {
    * @param {Object} connection
    * @param {Function} cb
    */
-  DB2.prototype.rollback = function(connection, cb) {
+  DASHDB.prototype.rollback = function(connection, cb) {
     debug('Rollback a transaction');
     connection.rollbackTransaction(function(err) {
       if (err) return cb(err);

--- a/test/dashdb.transaction.test.js
+++ b/test/dashdb.transaction.test.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-var describe = require('./describe');
-
 /* eslint-env node, mocha */
 process.env.NODE_ENV = 'test';
 

--- a/test/dashdb.transaction.test.js
+++ b/test/dashdb.transaction.test.js
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-dashdb
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var describe = require('./describe');
+
+/* eslint-env node, mocha */
+process.env.NODE_ENV = 'test';
+
+require('./init.js');
+require('should');
+
+var Transaction = require('loopback-connector').Transaction;
+
+var db, Post;
+
+describe('transactions', function() {
+  describe('commit and rollback', function() {
+    before(function(done) {
+      db = global.getDataSource();
+
+      Post = db.define('PostTX', {
+        title: {type: String, length: 255, index: true},
+        content: {type: String},
+      });
+      db.automigrate('PostTX', done);
+    });
+
+    var currentTx;
+    // Return an async function to start a transaction and create a post
+    function createPostInTx(post) {
+      return function(done) {
+        Transaction.begin(db.connector, Transaction.READ_COMMITTED,
+          function(err, tx) {
+            if (err) return done(err);
+            currentTx = tx;
+            Post.create(post, {transaction: tx},
+              function(err, p) {
+                if (err) {
+                  done(err);
+                } else {
+                  done();
+                }
+              });
+          });
+      };
+    }
+
+    // Return an async function to find matching posts and assert number of
+    // records to equal to the count
+    function expectToFindPosts(where, count, inTx) {
+      return function(done) {
+        var options = {};
+        if (inTx) {
+          options.transaction = currentTx;
+        }
+        Post.find({where: where}, options,
+          function(err, posts) {
+            if (err) return done(err);
+            posts.length.should.be.eql(count);
+            done();
+          });
+      };
+    }
+
+    describe('commit', function() {
+      var post = {title: 't1', content: 'c1'};
+      before(createPostInTx(post));
+
+      it('should not see the uncommitted insert',
+         expectToFindPosts(post, 0));
+
+      it('should see the uncommitted insert from the same transaction',
+        expectToFindPosts(post, 1, true));
+
+      it('should commit a transaction', function(done) {
+        currentTx.commit(done);
+      });
+
+      it('should see the committed insert', expectToFindPosts(post, 1));
+    });
+
+    describe('rollback', function() {
+      var post = {title: 't2', content: 'c2'};
+      before(createPostInTx(post));
+
+      it('should not see the uncommitted insert',
+        expectToFindPosts(post, 0));
+
+      it('should see the uncommitted insert from the same transaction',
+        expectToFindPosts(post, 1, true));
+
+      it('should rollback a transaction', function(done) {
+        currentTx.rollback(done);
+      });
+
+      it('should not see the rolledback insert', expectToFindPosts(post, 0));
+    });
+  });
+});

--- a/test/describe.js
+++ b/test/describe.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = process.env.CI ? describe.skip.bind(describe) : describe;

--- a/test/describe.js
+++ b/test/describe.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = process.env.CI ? describe.skip.bind(describe) : describe;


### PR DESCRIPTION
### Description
The current method of setting isolation level in the connection string passed to the ODBC driver will result in isolationLevel being added to the connection string over and over which results in a new connection being added to the pool for each transaction.  This results in the appearance of a memory leak when really we are exhausting the number of available connections on to the database.  Some users will see a max connections error while others will hit memory limits on their system.

This issue was already resolved in the DB2 connector with the same change.  All tests pass with the new code and this fix if for a customer that has shown the "memory leak" in node inspector.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
