### PR TITLE
Update counts

### DIFF
--- a/lib/dashdb.js
+++ b/lib/dashdb.js
@@ -71,10 +71,11 @@ DASHDB.prototype.update = function(model, where, data, options, cb) {
   var self = this;
   var stmt = self.buildUpdate(model, where, data, options);
   var idName = self.idColumn(model);
-  var sql = 'SELECT \"' + idName + '\" FROM FINAL TABLE (' + stmt.sql + ')';
+  var sql = 'SELECT COUNT(\"' + idName + '\") AS \"affectedRows\" ' +
+            'FROM FINAL TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
-      cb(err, {count: info.length});
+      cb(err, {count: info[0].affectedRows});
     }
   });
 };
@@ -91,10 +92,11 @@ DASHDB.prototype.destroyAll = function(model, where, options, cb) {
   var self = this;
   var stmt = self.buildDelete(model, where, options);
   var idName = self.idColumn(model);
-  var sql = 'SELECT \"' + idName + '\" FROM OLD TABLE (' + stmt.sql + ')';
+  var sql = 'SELECT COUNT(\"' + idName + '\") AS \"affectedRows\" ' +
+            'FROM OLD TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
-      cb(err, {count: info.length});
+      cb(err, {count: info[0].affectedRows});
     }
   });
 };


### PR DESCRIPTION
### Description
update and destroyAll functions were using a non-optimal query to return the number of rows updated/deleted.  This change limits the data transfer required to a single value per execution regardless of how many rows are changed.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x ] New tests added or existing tests modified to cover all changes
- [ x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
