### PR TITLE
Revert "Run posttest even when test fails"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "eslint .",
     "pretest": "node pretest.js",
-    "test": "mocha --timeout 20000 --require test/init.js || :",
+    "test": "mocha --timeout 20000 --require test/init.js",
     "posttest": "node posttest.js && npm run lint"
   },
   "dependencies": {


### PR DESCRIPTION
# Description

This PR needs to be reverted since this solution is potentially dangerous. CI will still be green if the tests fail because of the overall operation exiting as a **success** rather than a **failure**.

Reverts strongloop/loopback-connector-dashdb#55