### PR TITLE
Update #buildQueryPrimaryKeys in ./lib/discover.js

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -206,7 +206,7 @@ function mixinDiscovery(DASHDB, dashdb) {
       ' colseq AS "keySeq",' +
       ' constname AS "pkName"' +
       ' FROM syscat.keycoluse' +
-      ' WHERE constname = \'PRIMARY\'';
+      ' WHERE constname LIKE \'%_PK\'';
 
     if (schema) {
       sql += ' AND tabschema = \'' + schema + '\'';


### PR DESCRIPTION
- amend WHERE clause in sql to account for syscat.keycoluse CONSTNAME col formatting "<MODEL_NAME>_PK"

### Description

Current method #buildQueryPrimaryKeys fails to return a result due to the sql WHERE clause searching for the hard-coded string 'PRIMARY'. The formatting for the column is <MODEL_NAME>_PK

#### Related issues

<!--
Please use the following link syntaxes:
- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes - covered by current tests
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
