### PR TITLE
Remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
- - 6
- - 8
- - 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
- - 4
  - 6
+ - 8
+ - 10


### PR DESCRIPTION
### Description
~Drop Node.js 4 in Travis~ 
From https://github.com/strongloop/loopback-connector-dashdb/pull/75#issuecomment-417052602, there is no need for `.travis.yml`. 