### PR TITLE
remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
- - 4
- - 6


### PR DESCRIPTION
### Description
From https://github.com/strongloop/loopback-connector-dashdb/pull/75#issuecomment-417052602, there is no need for `.travis.yml`. 
