### PR TITLE
chore: improve steps for running 'npm test'

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ SET CI=true
 npm test
 ```
 
+The value for `DASHDB_SCHEMA` must be of the pattern `SCHEMA{build number}_{build name}_{platform}_{node version}`.
+For example : **SCHEMA1_DASHDB_DARWIN_10**.
+
+Alternatively, let `DASHDB_SCHEMA` be computed for you by setting these values instead:
+
+```bash
+export PACKAGE_NAME=loopback-connector-dashdb 
+export BUILD_NUMBER={build number}   For example: 1
+export nodeVersion={node version}    For example: 10
+```
+
+This will create a schema with the name: **SCHEMA1_DASHDB_DARWIN_10**
+
+This pattern of the schema name is important for database **cleanup** and **seeding** purposes.
+
 ### Docker
 - DashDB has a docker image which could be signed up for a trial version and be used for testing. For more information, please visit: [DashDB Docker](https://hub.docker.com/r/dashdb/local/)
 - Once the instance is ready, please follow the above information on how to run tests using your [own instance](https://github.com/strongloop/loopback-connector-dashdb/tree/master#own-instance)


### PR DESCRIPTION
### Description

When running 'npm test' locally it is important to set some environment variables.

The value of `DASHDB_SCHEMA` **must** be set to a specific pattern; otherwise certain tests fail because some **cleanup** doesn't occur beforehand.

Or  **other** variables 

```
PACKAGE_NAME 
BUILD_NUMBER
nodeVersion
```

can be set to **compute** the schema name ( following the proper pattern) for the user.

This is how the Jenkins job sets up the environment variables before running `npm test`, and the
user should do it to see the same results.

Big thanks to @b-admike for helping me debug this.

It solves the failure 

```sh
1) Discover and build models
       should discover and build models:

      Uncaught AssertionError [ERR_ASSERTION]: error should not be reported
      + expected - actual

      -false
      +true
``` 

I experienced when running `npm test` locally.  The value I specified for `DASHDB_SCHEMA` didn't follow the pattern and was causing the failure.

With the env variables properly set, all tests are passing.


#### Related issues

connect to #76 

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
