### PR TITLE
fix: add tests for 'table' and 'columnName' usage in model definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^3.1.0",
     "debug": "^4.1.1",
     "loopback-connector": "^4.0.0",
-    "loopback-ibmdb": "^2.3.0",
+    "loopback-ibmdb": "^2.6.0",
     "strong-globalize": "^5.0.0"
   },
   "devDependencies": {

--- a/test/dashdb.columnName.test.js
+++ b/test/dashdb.columnName.test.js
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback-connector-dashdb
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+/* eslint-env node, mocha */
+process.env.NODE_ENV = 'test';
+
+require('./init.js');
+const assert = require('assert');
+
+let id, db, Book;
+const BOOK_TITLE = 'Rocky I';
+const REVISED_BOOK_TITLE = 'Rocky II';
+
+/*
+   This test suite is to test the changes surrounding the fix
+   in loopback-ibmdb related to issue :
+   https://github.com/strongloop/loopback-ibmdb/issues/79
+*/
+
+describe('replaceById with custom column name for id', () => {
+  // 'table' option specified since we want a table 'BOOK'
+  // to be created for model 'Book'
+  const BOOK_TABLE_OPTIONS = {
+    dashdb: {
+      table: 'BOOK',
+    },
+  };
+    // 'columnName' options specified since  want columns 'BOOK_ID' and 'TITLE'
+    // to be created instead of 'bookId' and 'title'
+  const BOOK_PROPERTIES = {
+    bookId: {
+      type: Number,
+      id: true,
+      generated: true,
+      dashdb: {
+        columnName: 'BOOK_ID',
+      },
+    },
+    title: {
+      type: String,
+      dashdb: {
+        columnName: 'TITLE',
+      },
+    },
+  };
+  before(() => {
+    db = global.getDataSource();
+    Book = db.define('Book', BOOK_PROPERTIES, BOOK_TABLE_OPTIONS);
+  });
+  it('create and replace a book', async () => {
+    await db.automigrate('Book');
+    const newBook = await Book.create({title: BOOK_TITLE});
+    assert(newBook);
+    assert.equal(newBook.title, BOOK_TITLE);
+    id = newBook.id;
+    const updatedBook = await Book.replaceById(id, {title: REVISED_BOOK_TITLE});
+    assert(updatedBook);
+    assert.equal(updatedBook.id, id);
+    assert.equal(updatedBook.title, REVISED_BOOK_TITLE);
+  });
+});
+
+describe('replaceById with model name for id', () => {
+  // No 'table' option specified since we want a table 'Book'
+  // to be created for model 'Book'
+
+  // No 'columnName' options specified since we want columns 'bookId' and 'title'
+  // to be created for properties 'bookId' and 'title'
+  const BOOK_PROPERTIES = {
+    bookId: {
+      type: Number,
+      id: true,
+      generated: true,
+    },
+    title: {
+      type: String,
+    },
+  };
+  before(() => {
+    db = global.getDataSource();
+    Book = db.define('Book', BOOK_PROPERTIES);
+  });
+  it('create and replace a book', async () => {
+    await db.automigrate('Book');
+    const newBook = await Book.create({title: BOOK_TITLE});
+    assert(newBook);
+    assert.equal(newBook.title, BOOK_TITLE);
+    id = newBook.id;
+    const updatedBook = await Book.replaceById(id, {title: REVISED_BOOK_TITLE});
+    assert(updatedBook);
+    assert.equal(updatedBook.id, id);
+    assert.equal(updatedBook.title, REVISED_BOOK_TITLE);
+  });
+});


### PR DESCRIPTION
This PR is providing the test cases for  a fix in loopback-ibmdb/lib/ibmdb.js' _replace() method (See [PR #80](https://github.com/strongloop/loopback-ibmdb/pull/80)  ).

The test cases should exercise loopback-datasource-juggler/lib/dao.js' `replaceById()` function so that it calls loopback-ibmdb/lib/ibmdb.js' `_replace()` function.

We should have : 

 - one test case that **does** use `table` and `columnName` values in the model and property definitions
 - one test case that **does not** use the `table` and `columnName` values in the model and property definitions
- each test case should perform a `create`, followed by a `replaceById`

These test cases cannot be placed in the 
`https://github.com/strongloop/loopback-next/tree/master/packages/repository-tests` test suites
since these test cases are generic and don't specify connector-specific overrides like:

```
"dashdb" : {
    "table" : "AWARD"
}
```

or

```
"dashdb" : {
    "columnName" : "AWARD_ID"
}
```

## Related Issue

connect to: https://github.com/strongloop/loopback-ibmdb/issues/79 

Dependent on PR https://github.com/strongloop/loopback-ibmdb/pull/80
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-dashdb) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
